### PR TITLE
Add cloudwatch event target

### DIFF
--- a/README.md
+++ b/README.md
@@ -80,6 +80,7 @@ No Modules.
 |------|
 | [aws_caller_identity](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/caller_identity) |
 | [aws_cloudwatch_event_rule](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_rule) |
+| [aws_cloudwatch_event_target](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/cloudwatch_event_target) |
 | [aws_guardduty_detector](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_detector) |
 | [aws_guardduty_publishing_destination](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/guardduty_publishing_destination) |
 | [aws_iam_policy_document](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) |
@@ -96,9 +97,10 @@ No Modules.
 | enable | Enable monitoring and feedback reporting.  Setting to false is equivalent to "suspending" GuardDuty. | `bool` | `true` | no |
 | finding\_publishing\_frequency | Specifies the frequency of notifications sent for subsequent finding occurrences.  If the detector is a GuardDuty member account, the value is determined by the GuardDuty master account and cannot be modified, otherwise defaults to SIX\_HOURS.  For standalone and GuardDuty master accounts, it must be configured in Terraform to enable drift detection.  Valid values for standalone and master accounts: FIFTEEN\_MINUTES, ONE\_HOUR, SIX\_HOURS. | `string` | `"FIFTEEN_MINUTES"` | no |
 | kms\_alias\_name | The display name of the alias of the KMS key used to encrypt exports to S3. The name must start with the word "alias" followed by a forward slash (alias/). | `string` | `"alias/guardduty"` | no |
-| kms\_key\_tags | Tags to apply to the AWS KMS Key used to encrypt exports to S3. | `map(string)` | `{}` | no |
 | s3\_bucket\_name | The name of the S3 bucket that receives findings from GuardDuty.  If blank, then GuardDuty does not export findings to S3. | `string` | `""` | no |
-| s3\_bucket\_prefix | The prefix for where findings from GuardDuty are stored in the S3 bucket.  Should start with "/" if defined.  GuardDuty will build the full destination ARN using this format: <s3\_bucket\_arn><s3\_bucket\_prefix>/AWSLogs/<account\_id>/GuardDuty/<region>. | `string` | `"/guardduty"` | no |
+| s3\_bucket\_prefix | The prefix for where findings from GuardDuty are stored in the S3 bucket.  Should start with "/" if defined.  GuardDuty will build the full destination ARN using this format: S3BUCKETARNS3BUCKETPREFIX/AWSLogs/ACCOUNTID/GuardDuty/REGION. | `string` | `"/guardduty"` | no |
+| sns\_topic\_arn | The ARN of an SNS Topic to send events to. | `string` | `""` | no |
+| tags | Tags to apply to the AWS Resources. | `map(string)` | `{}` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -169,7 +169,7 @@ resource "aws_cloudwatch_event_rule" "guardduty_findings" {
 # More details about the response syntax can be found here:
 # https://docs.aws.amazon.com/guardduty/latest/ug/get-findings.html#get-findings-response-syntax
 resource "aws_cloudwatch_event_target" "guardduty_findings" {
-  count = length(var.sns_topic_arn) ? 1 : 0
+  count = length(var.sns_topic_arn) > 0 ? 1 : 0
 
   rule = aws_cloudwatch_event_rule.guardduty_findings.name
 

--- a/variables.tf
+++ b/variables.tf
@@ -30,7 +30,7 @@ variable "s3_bucket_name" {
 
 variable "s3_bucket_prefix" {
   type        = string
-  description = "The prefix for where findings from GuardDuty are stored in the S3 bucket.  Should start with \"/\" if defined.  GuardDuty will build the full destination ARN using this format: <s3_bucket_arn><s3_bucket_prefix>/AWSLogs/<account_id>/GuardDuty/<region>."
+  description = "The prefix for where findings from GuardDuty are stored in the S3 bucket.  Should start with \"/\" if defined.  GuardDuty will build the full destination ARN using this format: S3BUCKETARNS3BUCKETPREFIX/AWSLogs/ACCOUNTID/GuardDuty/REGION."
   default     = "/guardduty"
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -16,9 +16,9 @@ variable "kms_alias_name" {
   default     = "alias/guardduty"
 }
 
-variable "kms_key_tags" {
+variable "tags" {
   type        = map(string)
-  description = "Tags to apply to the AWS KMS Key used to encrypt exports to S3."
+  description = "Tags to apply to the AWS Resources."
   default     = {}
 }
 
@@ -32,4 +32,10 @@ variable "s3_bucket_prefix" {
   type        = string
   description = "The prefix for where findings from GuardDuty are stored in the S3 bucket.  Should start with \"/\" if defined.  GuardDuty will build the full destination ARN using this format: <s3_bucket_arn><s3_bucket_prefix>/AWSLogs/<account_id>/GuardDuty/<region>."
   default     = "/guardduty"
+}
+
+variable "sns_topic_arn" {
+  type        = string
+  description = "The ARN of an SNS Topic to send events to."
+  default     = ""
 }


### PR DESCRIPTION
I want to eliminate the extra code I'd need to write to set this up everywhere. Should be a no-op if the SNS topic is not provided. Also, I'm generalizing the list of tags like in other modules.